### PR TITLE
Fix "comparison of Float with nil failed"

### DIFF
--- a/lib/fluent/plugin/out_numeric_monitor.rb
+++ b/lib/fluent/plugin/out_numeric_monitor.rb
@@ -192,10 +192,10 @@ class Fluent::Plugin::NumericMonitorOutput < Fluent::Plugin::Output
     @mutex.synchronize do
       c = (@count[tag] ||= {min: nil, max: nil, sum: nil, num: 0})
 
-      if c[:min].nil? or c[:min] > min
+      if c[:min].nil? or (min and c[:min] > min)
         c[:min] = min
       end
-      if c[:max].nil? or c[:max] < max
+      if c[:max].nil? or (max and c[:max] < max)
         c[:max] = max
       end
       c[:sum] = (c[:sum] || 0) + sum


### PR DESCRIPTION
```
2024-07-01 18:29:11 +0900 [warn]: #0 emit transaction failed: error_class=ArgumentError error="comparison of Float with nil failed" location="/var/lib/td-agent/vendor/bundle/ruby/3.1.0/gems/fluent-plugin-numeric-monitor-1.0.3/lib/fluent/plugin/out_numeric_monitor.rb:195:in `>'" tag="*******************"
```